### PR TITLE
Add default value to init() / Fix error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/effector-localstorage.svg)](https://www.npmjs.com/package/effector-localstorage)
 
-Minimalistic (120 B) module for [effector](https://github.com/zerobias/effector) that sync stores with `localStorage`.
+Minimalistic (130 B) module for [effector](https://github.com/zerobias/effector) that sync stores with `localStorage`.
 
 ```javascript
 import {createStore, createEvent} from 'effector'
@@ -15,7 +15,7 @@ const resetCounter = createEvent('reset counter')
 const counterLocalStorage = connectLocalStorage("counter")
   .onError((err) => console.log(err)) // setup error callback
 
-const counter = createStore(counterLocalStorage.init() || 0) // initialize store with localStorage value
+const counter = createStore(counterLocalStorage.init(0)) // initialize store with localStorage value
   .on(increment, state => state + 1)
   .on(decrement, state => state - 1)
   .reset(resetCounter)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module "effector-localstorage" {
   interface Holder {
-    init: () => any
+    init: (def?: any) => any
     onError: (handler: (err: any) => void) => Holder
     (storeValue: any): Holder
   }

--- a/index.js
+++ b/index.js
@@ -5,23 +5,24 @@ function connectLocalStorage (key) {
       var saveState = JSON.stringify(storeValue)
       localStorage.setItem(key, saveState)
     } catch (err) {
-      holder.onError && holder.onError(err)
+      holder.errorHandler(err)
     }
   }
+  holder.errorHandler = function () {}
   holder.onError = function (errorHandler) {
     holder.errorHandler = errorHandler
     return holder
   }
-  holder.init = function () {
+  holder.init = function (def) {
     try {
       var savedState = localStorage.getItem(key)
       if (savedState !== null) {
         return JSON.parse(savedState)
       }
     } catch (err) {
-      holder.onError && holder.onError(err)
+      holder.errorHandler(err)
     }
-    return null
+    return def === undefined ? null : def
   }
   return holder
 }

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,7 +1,7 @@
 // @flow
 
 type Holder = {
-    init: () => any,
+    init: (def?: any) => any,
     onError: ((err: any) => mixed) => Holder,
     (storeValue: any): Holder
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "size-limit": [
     {
-      "limit": "120 B",
+      "limit": "130 B",
       "path": "index.js"
     }
   ],


### PR DESCRIPTION
- New feature:

Default value for `init()` call, solves problem, when you want to save `<number | null>` store → in that case `(..init() || null)` will set `null` value instead of saved `0`, for example

- Fix error handling

In case of error `onError` was called, instead of `errorHandler`

Unfortunately size was slightly increased...