### PR TITLE
Add 'storage' event support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![npm version](https://img.shields.io/npm/v/effector-localstorage.svg)](https://www.npmjs.com/package/effector-localstorage)
 
-Minimalistic (171 B) module for [effector](https://github.com/zerobias/effector) that sync stores with `localStorage`.
+Minimalistic (151 B) module for [effector](https://github.com/zerobias/effector) that sync stores with `localStorage`.
 
 ```javascript
 import {createStore, createEvent} from 'effector'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![npm version](https://img.shields.io/npm/v/effector-localstorage.svg)](https://www.npmjs.com/package/effector-localstorage)
 
-Minimalistic (111 B) module for [effector](https://github.com/zerobias/effector) that sync stores with `localStorage`.
+Minimalistic (171 B) module for [effector](https://github.com/zerobias/effector) that sync stores with `localStorage`.
 
 ```javascript
 import {createStore, createEvent} from 'effector'
@@ -11,15 +11,18 @@ import connectLocalStorage from "effector-localstorage";
 const increment = createEvent('increment')
 const decrement = createEvent('decrement')
 const resetCounter = createEvent('reset counter')
+const setCounter = createEvent('set counter')
 
 const counterLocalStorage = connectLocalStorage("counter")
   .onError((err) => console.log(err)) // setup error callback
+  .onChange(setCounter) // call event on external storage change
 
 const counter = createStore(counterLocalStorage.init(0)) // initialize store with localStorage value
   .on(increment, state => state + 1)
   .on(decrement, state => state - 1)
+  .on(setCounter, (state, value) => value)
   .reset(resetCounter)
-  
+
 counter.watch(counterLocalStorage) // update localStorage on every store change
 ```
 View example at [codesandbox](https://codesandbox.io/s/effector-localstorage-85czp) or [repository](/example).
@@ -36,7 +39,7 @@ Or with npm:
 
 ```
 npm i effector-localstorage --save
-``` 
+```
 
 ## Sponsored
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ declare module "effector-localstorage" {
   interface Holder {
     init: (value?: any) => any
     onError: (handler: (err: any) => void) => Holder
+    onChange: (event: (value: any) => any) => Holder
     (storeValue: any): Holder
   }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 function connectStorage (key, storage) {
-  storage = storage || window.localStorage
+  storage = storage || localStorage
   var errorHandler = function () {} // eslint-disable-line func-style
 
   function holder (value) {
@@ -16,8 +16,8 @@ function connectStorage (key, storage) {
   }
 
   holder.onChange = function (event) {
-    window.addEventListener('storage', function (e) {
-      e.key === key && e.storageArea === storage && event(holder.init())
+    addEventListener('storage', function (e) {
+      e.key === key && event(holder.init())
     })
     return holder
   }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-function connectLocalStorage (key, storage) {
+function connectStorage (key, storage) {
   storage = storage || window.localStorage
   var errorHandler = function () {} // eslint-disable-line func-style
 
@@ -15,6 +15,13 @@ function connectLocalStorage (key, storage) {
     return holder
   }
 
+  holder.onChange = function (event) {
+    window.addEventListener('storage', function (e) {
+      e.key === key && e.storageArea === storage && event(holder.init())
+    })
+    return holder
+  }
+
   holder.init = function (value) {
     try {
       value = JSON.parse(storage.getItem(key))
@@ -27,4 +34,4 @@ function connectLocalStorage (key, storage) {
   return holder
 }
 
-module.exports = connectLocalStorage
+module.exports = connectStorage

--- a/index.js.flow
+++ b/index.js.flow
@@ -3,6 +3,7 @@
 type Holder = {
     init: (value?: any) => any,
     onError: ((err: any) => mixed) => Holder,
+    onChange: (event: (value: any) => any) => Holder,
     (storeValue: any): Holder
 }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "size-limit": [
     {
-      "limit": "171 B",
+      "limit": "151 B",
       "path": "index.js"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "size-limit": [
     {
-      "limit": "111 B",
+      "limit": "171 B",
       "path": "index.js"
     }
   ],


### PR DESCRIPTION
Controversial PR I talked about :)

Local storage has one awesome feature — it can be _synced_ between two (or more) widows/tabs. Window has [`storage`](https://www.w3schools.com/jsref/event_storage_url.asp) event, which is only triggered when a window **other than itself** makes the changes.

So I added `.onChange` method, which accepts effector's event to set Store value to new one, which came from another window/tab.

This way it is possible to synchronise counter on two tabs of a browser. Or, closer to reality, abstract flag `authenticated`, when user performs logout on one tab — that triggers logout on all other opened tabs with the same application.

This additional functionality easy to implement outside of this package, but I think it is appropriate and nifty place to have such feature.

But this increased size on a whole 60 B :( And I don't know, how to decrease it now.

So, discuss :)