### PR TITLE
Fix initial store value

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![npm version](https://img.shields.io/npm/v/effector-localstorage.svg)](https://www.npmjs.com/package/effector-localstorage)
 
-Minimalistic (99 B) module for [effector](https://github.com/zerobias/effector) that sync stores with `localStorage`.
+Minimalistic (102 B) module for [effector](https://github.com/zerobias/effector) that sync stores with `localStorage`.
 
 ```javascript
 import {createStore, createEvent} from 'effector'

--- a/index.js
+++ b/index.js
@@ -16,11 +16,12 @@ function connectStorage (key) {
 
   holder.init = function (value) {
     try {
-      value = JSON.parse(localStorage.getItem(key))
+      var item = localStorage.getItem(key)
+      return item === null ? value : JSON.parse(item)
     } catch (err) {
       errorHandler && errorHandler(err)
     }
-    return value == null ? null : value
+    return value
   }
 
   return holder

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   },
   "size-limit": [
     {
-      "limit": "99 B",
+      "limit": "102 B",
       "path": "index.js"
     },
     {
-      "limit": "146 B",
+      "limit": "149 B",
       "path": "sync.js"
     }
   ],

--- a/sync.js
+++ b/sync.js
@@ -23,11 +23,12 @@ function connectStorage (key) {
 
   holder.init = function (value) {
     try {
-      value = JSON.parse(localStorage.getItem(key))
+      var item = localStorage.getItem(key)
+      return item === null ? value : JSON.parse(item)
     } catch (err) {
       errorHandler && errorHandler(err)
     }
-    return value == null ? null : value
+    return value
   }
 
   return holder


### PR DESCRIPTION
Fix issue, when there is no item in local storage — store is always initialised with `null`, instead of given initial value:

```jabascript
const store = createStore(storeLocalStorage.init([]))
```
↑ this will set `null` to store, regardless of given `[]`.

This PR should fix this issue, as I've fixed it in my library:
https://github.com/yumauri/effector-storage/commit/8a6068767778eb94a6a76b6edba2ff382b2cb2b1